### PR TITLE
Add omitNamespaceRootInPath option to Psr4FileManager

### DIFF
--- a/bin/model-generator
+++ b/bin/model-generator
@@ -15,13 +15,14 @@ use Cds\NetteModelGenerator\Reflections\PostgreSqlReflection;
 const AllowedDrivers = ['mysql', 'pgsql'];
 
 $options = getopt(
-    short_options: 'd:n:s:ir:e:H:D:U:P:p:h',
+    short_options: 'd:n:s:ir:e:o:H:D:U:P:p:h',
     long_options: [
         'driver:',
         'schemas:',
         'include-schema',
         'root-dir:',
         'namespace:',
+        'omit-namespace-root:',
         'host:',
         'dbname:',
         'user:',
@@ -85,6 +86,15 @@ if ($password === null) {
     exit(1);
 }
 
+$namespace = $options['e'] ?? $options['namespace'] ?? null;
+$omitNamespaceRootInPath = $options['o'] ?? $options['omit-namespace-root'] ?? null;
+if ($omitNamespaceRootInPath !== null && !str_contains($namespace, $omitNamespaceRootInPath)) {
+    printError('Namespace root must be a part of the namespace.');
+    printHelp();
+
+    exit(1);
+}
+
 // Prepare a connection to the database.
 $port = $options['port'] ?? null;
 $connection = new Nette\Database\Connection(
@@ -108,8 +118,9 @@ $context = new GeneratorContext(
     },
     fileManager: new Psr4FileManager(
         rootDir: parseRootDir($rootDir),
-        namespace: parseNamespace($options['e'] ?? $options['namespace'] ?? null),
+        namespace: parseNamespace($namespace),
         includeSchema: isset($options['i']) || isset($options['include-schema']),
+        omitNamespaceRootInPath: $omitNamespaceRootInPath,
     ),
     fileWriter: new FileWriter(),
     printer: new Nette\PhpGenerator\PsrPrinter(),
@@ -179,10 +190,11 @@ function printHelp(): void
         -r, --root-dir  Root directory for generated files.
 
       Optional:
-        -p, --port            Database port.
-        -s, --schemas         [pgsql only] Comma-separated list of schemas to include (optional).
-        -i, --include-schema  [pgsql only] Include schema name in generated class names and paths (optional).
-        -e, --namespace       Namespace for generated classes (default: App\\Model).
+        -p, --port                 Database port.
+        -s, --schemas              [pgsql only] Comma-separated list of schemas to include (optional).
+        -i, --include-schema       [pgsql only] Include schema name in generated class names and paths (optional).
+        -e, --namespace            Namespace for generated classes (default: App\\Model).
+        -o, --omit-namespace-root  Namespace part ignored when generating PSR-4 structure for model (optional).
 
       -h, --help      Display this help message.\n
     HELP;

--- a/src/Psr4FileManager.php
+++ b/src/Psr4FileManager.php
@@ -17,7 +17,8 @@ readonly class Psr4FileManager implements FileManager
     public function __construct(
         private array $rootDir,
         private array $namespace,
-        private bool $includeSchema = false
+        private bool $includeSchema = false,
+        private string|null $omitNamespaceRootInPath = null
     ) {
         if (empty($rootDir)) {
             throw new \InvalidArgumentException('Root directory must not be empty.');
@@ -150,6 +151,12 @@ readonly class Psr4FileManager implements FileManager
 
     private function joinPathParts(string ...$parts): string
     {
+        $parts = array_filter(
+            array: $parts,
+            callback: static fn ($part, $index) => $index === 0 || $part !== '',
+            mode: ARRAY_FILTER_USE_BOTH
+        );
+
         return implode(DIRECTORY_SEPARATOR, $parts);
     }
 
@@ -176,7 +183,7 @@ readonly class Psr4FileManager implements FileManager
     }
 
     /**
-     * If the root directory is equal to the first namespace part, remove it from the namespace.
+     * Adjusts the namespace path based on the root directory and namespace configuration.
      *
      * @param array<string> $namespace
      *
@@ -188,6 +195,16 @@ readonly class Psr4FileManager implements FileManager
             return $namespace;
         }
 
+        // Remove root namespace from the path if specified.
+        if ($this->omitNamespaceRootInPath !== null) {
+            $namespaceStr = implode('\\', $namespace);
+            $namespaceStr = str_replace($this->omitNamespaceRootInPath, '', $namespaceStr);
+            $namespaceStr = ltrim($namespaceStr, '\\');
+
+            return explode('\\', $namespaceStr);
+        }
+
+        // Root directory name is equal to the first namespace part, remove it.
         if (strtolower($this->rootDir[count($this->rootDir) - 1]) === strtolower($this->namespace[0])) {
             return array_slice($namespace, 1);
         }

--- a/tests/Unit/Psr4FileManagerTest.php
+++ b/tests/Unit/Psr4FileManagerTest.php
@@ -19,14 +19,18 @@ class Psr4FileManagerTest extends TestCase
     public function emptyRootDir(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Root directory must not be empty');
-        new Psr4FileManager([], []);
+        $this->expectExceptionMessage('Root directory must not be empty.');
+        new Psr4FileManager(rootDir: [], namespace: []);
     }
 
     #[Test]
     public function paths(): void
     {
-        $fileManager = new Psr4FileManager(['root'], ['App', 'Namespace', 'Test'], false);
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: ['App', 'Namespace', 'Test'],
+            includeSchema: false
+        );
         $table = new Table('test_table');
         $enum = new Enum('column_with_enum', ['value1', 'value2']);
 
@@ -68,7 +72,11 @@ class Psr4FileManagerTest extends TestCase
     #[Test]
     public function pathsNamespaceStartsWithRootDir(): void
     {
-        $fileManager = new Psr4FileManager(['root'], ['Root', 'Namespace', 'Test'], false);
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: ['Root', 'Namespace', 'Test'],
+            includeSchema: false
+        );
         $table = new Table('test_table');
         $enum = new Enum('column_with_enum', ['value1', 'value2']);
 
@@ -101,7 +109,11 @@ class Psr4FileManagerTest extends TestCase
     #[Test]
     public function pathsEmptyNamespace(): void
     {
-        $fileManager = new Psr4FileManager(['root'], [], false);
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: [],
+            includeSchema: false
+        );
         $table = new Table('test_table');
         $enum = new Enum('column_with_enum', ['value1', 'value2']);
 
@@ -120,9 +132,46 @@ class Psr4FileManagerTest extends TestCase
     }
 
     #[Test]
+    public function pathsNamespaceRoot(): void
+    {
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: ['App', 'Model'],
+            includeSchema: false,
+            omitNamespaceRootInPath: 'App'
+        );
+        $table = new Table('test_table');
+        $enum = new Enum('column_with_enum', ['value1', 'value2']);
+
+        $this->assertSame('root/Model/Generated/Explorer.php', $fileManager->getExplorerPath());
+        $this->assertSame('root/Model/Generated/Manager.php', $fileManager->getManagerPath());
+        $this->assertSame(
+            'root/Model/Generated/Managers/TestTableManagerBase.php',
+            $fileManager->getBaseManagerForTablePath($table)
+        );
+        $this->assertSame(
+            'root/Model/Generated/Rows/TestTableActiveRowBase.php',
+            $fileManager->getActiveRowPath($table)
+        );
+        $this->assertSame('root/Model/Generated/Enums/ColumnWithEnum.php', $fileManager->getEnumPath($enum));
+        $this->assertSame('root/Model/Generated/Columns/TestTable.php', $fileManager->getColumnsPath($table));
+
+        $this->assertSame('root/Model/Managers/ManagerBase.php', $fileManager->getBaseManagerPath());
+        $this->assertSame(
+            'root/Model/Managers/TestTableManager.php',
+            $fileManager->getUserManagerForTablePath($table)
+        );
+        $this->assertSame('root/Model/Rows/TestTableActiveRow.php', $fileManager->getUserActiveRowPath($table));
+    }
+
+    #[Test]
     public function pathsWithSchema(): void
     {
-        $fileManager = new Psr4FileManager(['root'], ['App', 'Namespace', 'Test'], true);
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: ['App', 'Namespace', 'Test'],
+            includeSchema: true
+        );
         $table = new Table('test_table', 'schema');
         $enum = new Enum('column_with_enum', ['value1', 'value2'], 'schema');
 
@@ -161,7 +210,11 @@ class Psr4FileManagerTest extends TestCase
     #[Test]
     public function names(): void
     {
-        $fileManager = new Psr4FileManager(['root'], ['App', 'Namespace', 'Test'], false);
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: ['App', 'Namespace', 'Test'],
+            includeSchema: false
+        );
         $table = new Table('test_table');
         $enum = new Enum('column_with_enum', ['value1', 'value2']);
 
@@ -201,7 +254,11 @@ class Psr4FileManagerTest extends TestCase
     #[Test]
     public function namesWithSchema(): void
     {
-        $fileManager = new Psr4FileManager(['root'], ['App', 'Namespace', 'Test'], true);
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: ['App', 'Namespace', 'Test'],
+            includeSchema: true
+        );
         $table = new Table('test_table', 'schema');
         $enum = new Enum('column_with_enum', ['value1', 'value2'], 'schema');
 
@@ -216,12 +273,11 @@ class Psr4FileManagerTest extends TestCase
             'App\Namespace\Test\Generated\Rows\Schema\TestTableActiveRowBase',
             $fileManager->getActiveRowName($table)
         );
-        // TODO: schemas...
         $this->assertSame('App\\Namespace\\Test\\Rows', $fileManager->getActiveRowNamespace());
-        //        $this->assertSame(
-        //            'App\Namespace\Test\Generated\Enums\Schema\ColumnWithEnum',
-        //            $fileManager->getEnumName($enum)
-        //        );
+        $this->assertSame(
+            'App\Namespace\Test\Generated\Enums\Schema\ColumnWithEnum',
+            $fileManager->getEnumName($enum)
+        );
         $this->assertSame(
             'App\Namespace\Test\Generated\Columns\Schema\TestTable',
             $fileManager->getColumnsName($table)
@@ -242,7 +298,11 @@ class Psr4FileManagerTest extends TestCase
     #[Test]
     public function namesWithoutNamespace(): void
     {
-        $fileManager = new Psr4FileManager(['root'], [], false);
+        $fileManager = new Psr4FileManager(
+            rootDir: ['root'],
+            namespace: [],
+            includeSchema: false
+        );
         $table = new Table('test_table');
         $enum = new Enum('column_with_enum', ['value1', 'value2']);
 


### PR DESCRIPTION
Introduced omitNamespaceRootInPath parameter to exclude a namespace segment from generated PSR-4 paths

Fixes #5 